### PR TITLE
(feat) Update the way addons are mapped

### DIFF
--- a/src/project-roots.ts
+++ b/src/project-roots.ts
@@ -5,7 +5,7 @@ import { logError, logInfo } from './utils/logger';
 import * as walkSync from 'walk-sync';
 import { URI } from 'vscode-uri';
 import * as fs from 'fs';
-import { isGlimmerXProject, isELSAddonRoot, isRootStartingWithFilePath, isProjectAddonRoot } from './utils/layout-helpers';
+import { isGlimmerXProject, isELSAddonRoot, isRootStartingWithFilePath, isProjectAddonRoot, getPackageJSON } from './utils/layout-helpers';
 
 import Server from './server';
 
@@ -68,6 +68,16 @@ export default class ProjectRoots {
     this.disableInitialization = disableInitialization || false;
   }
 
+  /**
+   * Returns true If the project is a parent project of an ember project.
+   * @param root string
+   */
+  isParentProject(root: string): boolean {
+    const potentialParentRoot = getPackageJSON(root);
+
+    return potentialParentRoot && !!potentialParentRoot['ember-addon']?.projectRoot;
+  }
+
   findProjectsInsideRoot(workspaceRoot: string) {
     const roots = walkSync(workspaceRoot, {
       directories: false,
@@ -81,7 +91,7 @@ export default class ProjectRoots {
 
       if (filePath.endsWith('package.json')) {
         try {
-          if (isGlimmerXProject(fullPath)) {
+          if (isGlimmerXProject(fullPath) || this.isParentProject(fullPath)) {
             this.onProjectAdd(fullPath);
           }
         } catch (e) {


### PR DESCRIPTION
This PR does the following:

- Adds support for multi level projects
- For namespaced addons, it uses the `moduleName` from the `index.js` of the addon instead of relying on the name of the folder (since the name of the folder can be different from module name)
- improvements to how the registry is built for projects that have `projectRoots` mentioned in their app.